### PR TITLE
Add replay determinism check and fix continue-as-new loop

### DIFF
--- a/.github/workflows/replay-determinism.yml
+++ b/.github/workflows/replay-determinism.yml
@@ -3,11 +3,6 @@ name: Replay Determinism Check
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "src/temporal/workflows/**"
-      - "src/bot/models.py"
-      - "src/bot/services.py"
-      - "tests/test_replay_determinism.py"
 
 jobs:
   replay-check:

--- a/.github/workflows/replay-determinism.yml
+++ b/.github/workflows/replay-determinism.yml
@@ -1,0 +1,51 @@
+name: Replay Determinism Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/temporal/workflows/**"
+      - "src/bot/models.py"
+      - "src/bot/services.py"
+      - "tests/test_replay_determinism.py"
+
+jobs:
+  replay-check:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Download running workflow histories
+        env:
+          TEMPORAL_ADDRESS: 192.168.101.240:7233
+          TEMPORAL_NAMESPACE: reddit-bots
+        run: |
+          mkdir -p replay_histories
+
+          workflow_ids=$(temporal workflow list \
+            --address "$TEMPORAL_ADDRESS" \
+            --namespace "$TEMPORAL_NAMESPACE" \
+            --query "ExecutionStatus='Running'" \
+            --output json \
+            | jq -r '.[].execution.workflowId')
+
+          for wid in $workflow_ids; do
+            echo "Downloading history for $wid"
+            temporal workflow show \
+              --address "$TEMPORAL_ADDRESS" \
+              --namespace "$TEMPORAL_NAMESPACE" \
+              --workflow-id "$wid" \
+              --output json > "replay_histories/${wid}.json"
+          done
+
+          echo "Downloaded $(ls replay_histories/*.json | wc -l) histories"
+
+      - name: Run replay determinism tests
+        env:
+          REPLAY_HISTORIES_DIR: replay_histories
+        run: uv run python -m unittest tests.test_replay_determinism -v

--- a/.github/workflows/replay-determinism.yml
+++ b/.github/workflows/replay-determinism.yml
@@ -17,6 +17,8 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
+      - uses: temporalio/setup-temporal@v0
+
       - name: Install dependencies
         run: uv sync
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .venv/
 .python-version
 .DS_Store
+replay_histories/

--- a/src/temporal/workflows/comment_processing.py
+++ b/src/temporal/workflows/comment_processing.py
@@ -120,6 +120,20 @@ class CommentPollingWorkflow:
             )
 
         while not self._should_stop:
+            if (
+                workflow.info().is_continue_as_new_suggested()
+                or workflow.info().is_target_worker_deployment_version_changed()
+            ):
+                workflow.logger.info("Continuing as new")
+                workflow.continue_as_new(
+                    args=[
+                        self._seen_ids,
+                        self._current_submission_id,
+                        self._previous_submission_id,
+                    ],
+                    initial_versioning_behavior=ContinueAsNewVersioningBehavior.AUTO_UPGRADE,
+                )
+
             self._submission_changed = False
 
             # Build list of active submission IDs (filtering None).
@@ -150,7 +164,6 @@ class CommentPollingWorkflow:
                     activity_handle.done()
                     or self._should_stop
                     or self._submission_changed
-                    # if we want this poller to bounce faster to the new version need to all watch current version here, or it will won't bounce until the new confirmation comment comes in
                     or workflow.info().is_target_worker_deployment_version_changed()
                 )
             )
@@ -240,20 +253,6 @@ class CommentPollingWorkflow:
                         comment_data.id,
                         workflow_id,
                     )
-
-            if (
-                workflow.info().is_continue_as_new_suggested()
-                or workflow.info().is_target_worker_deployment_version_changed()
-            ):
-                workflow.logger.info("Continuing as new")
-                workflow.continue_as_new(
-                    args=[
-                        self._seen_ids,
-                        self._current_submission_id,
-                        self._previous_submission_id,
-                    ],
-                    initial_versioning_behavior=ContinueAsNewVersioningBehavior.AUTO_UPGRADE,
-                )
 
         workflow.logger.info("Comment polling stopped")
         return self.get_status()

--- a/tests/test_replay_determinism.py
+++ b/tests/test_replay_determinism.py
@@ -1,0 +1,90 @@
+"""Replay determinism tests for all Temporal workflows.
+
+Replays workflow histories from JSON files against the current workflow code.
+If replay fails, the workflow code has introduced a non-deterministic change
+that would break in-flight workflow executions.
+
+History files are expected in the directory specified by the
+REPLAY_HISTORIES_DIR environment variable (defaults to ./replay_histories).
+Each file should be a JSON workflow history as produced by:
+    temporal workflow show --output json > history.json
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Required by bot.config at import time
+os.environ.setdefault("SUBREDDIT_NAME", "Pen_Swap")
+
+from temporalio.client import WorkflowHistory  # noqa: E402
+from temporalio.worker import Replayer  # noqa: E402
+from temporalio.worker.workflow_sandbox import (  # noqa: E402
+    SandboxedWorkflowRunner,
+    SandboxRestrictions,
+)
+
+from temporal.workflows.comment_processing import (  # noqa: E402
+    CommentPollingWorkflow,
+    ProcessConfirmationWorkflow,
+)
+from temporal.workflows.flair_coordinator import FlairCoordinatorWorkflow  # noqa: E402
+from temporal.workflows.monthly_post import MonthlyPostWorkflow  # noqa: E402
+
+ALL_WORKFLOWS = [
+    CommentPollingWorkflow,
+    ProcessConfirmationWorkflow,
+    FlairCoordinatorWorkflow,
+    MonthlyPostWorkflow,
+]
+
+HISTORIES_DIR = Path(
+    os.environ.get("REPLAY_HISTORIES_DIR", "replay_histories")
+)
+
+
+def _build_replayer() -> Replayer:
+    return Replayer(
+        workflows=ALL_WORKFLOWS,
+        workflow_runner=SandboxedWorkflowRunner(
+            restrictions=SandboxRestrictions.default.with_passthrough_modules(
+                "praw", "requests", "urllib3", "bot",
+            )
+        ),
+    )
+
+
+class ReplayDeterminismTest(unittest.IsolatedAsyncioTestCase):
+    """Replay workflow histories from JSON files against current code."""
+
+    async def test_replay_histories(self):
+        """Replay all history files in the histories directory."""
+        self.assertTrue(
+            HISTORIES_DIR.exists(),
+            f"Histories directory not found: {HISTORIES_DIR}",
+        )
+
+        history_files = sorted(HISTORIES_DIR.glob("*.json"))
+        self.assertTrue(
+            len(history_files) > 0,
+            f"No JSON history files found in {HISTORIES_DIR}",
+        )
+
+        replayer = _build_replayer()
+
+        for history_file in history_files:
+            workflow_id = history_file.stem
+
+            with self.subTest(workflow_id=workflow_id):
+                history = WorkflowHistory.from_json(
+                    workflow_id=workflow_id,
+                    history=history_file.read_text(),
+                )
+                await replayer.replay_workflow(history)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add CI workflow that replays running workflow histories against current code to gate non-deterministic changes
- Move continue-as-new check to top of polling loop to fix unreachable code path after activity cancellation

## Test plan
- [ ] Verify replay determinism workflow triggers on PRs touching workflow files
- [ ] Confirm self-hosted runner can reach Temporal cluster and download histories
- [ ] Test that intentional non-deterministic changes are caught by the replayer