### PR TITLE
Signal wake_up on worker startup for faster version drain

### DIFF
--- a/src/temporal/worker.py
+++ b/src/temporal/worker.py
@@ -86,6 +86,19 @@ def _build_runtime() -> Runtime | None:
     return runtime
 
 
+async def _signal_wake_up(client: Client) -> None:
+    """Signal running CommentPollingWorkflow to re-evaluate version changes."""
+    workflow_id = f"poll-{SUBREDDIT_NAME}"
+    try:
+        handle = client.get_workflow_handle(workflow_id)
+        await handle.signal(CommentPollingWorkflow.wake_up)
+        logger.info("Sent wake_up signal to %s", workflow_id)
+    except Exception:
+        logger.info(
+            "No running workflow %s to signal (may be first deploy)", workflow_id
+        )
+
+
 async def main():
     """Start the Temporal worker."""
     runtime = _build_runtime()
@@ -144,8 +157,16 @@ async def main():
     logger.info("Worker started. Press Ctrl+C to stop.")
 
     try:
-        await worker.run()
-    except KeyboardInterrupt:
+        async with worker:
+            # Worker is now polling — signal running workflows to wake up
+            # so they re-evaluate is_target_worker_deployment_version_changed().
+            # This is pretty unnecessary but I'm experimenting with how we make sure we quickly kick off
+            # managed upgrades with the worker controller, with workflows that have long running
+            # polling activities.
+            await _signal_wake_up(client)
+            # Block until shutdown
+            await asyncio.Future()
+    except (KeyboardInterrupt, asyncio.CancelledError):
         logger.info("Worker shutdown requested")
 
 

--- a/src/temporal/workflows/comment_processing.py
+++ b/src/temporal/workflows/comment_processing.py
@@ -9,7 +9,12 @@ from temporalio.exceptions import WorkflowAlreadyStartedError
 from temporalio.workflow import ContinueAsNewVersioningBehavior, ParentClosePolicy
 
 from bot.config import SUBREDDIT_NAME, TASK_QUEUE
-from bot.models import CommentData, FetchCommentsInput, FlairIncrementResult, ReplyToCommentInput
+from bot.models import (
+    CommentData,
+    FetchCommentsInput,
+    FlairIncrementResult,
+    ReplyToCommentInput,
+)
 from bot.services import ConfirmationService
 
 from ..activities import comments as comment_activities
@@ -52,6 +57,10 @@ class CommentPollingWorkflow:
     def stop(self) -> None:
         """Signal to stop the polling loop."""
         self._should_stop = True
+
+    @workflow.signal
+    def wake_up(self) -> None:
+        pass
 
     @workflow.signal
     def set_current_submission(self, submission_id: str) -> None:
@@ -302,7 +311,11 @@ class ProcessConfirmationWorkflow:
                         retry_policy=REDDIT_RETRY_POLICY,
                     )
                     await self._save(comment_id)
-                    return {"status": "rejected", "reason": validation.reason, "comment_id": comment_id}
+                    return {
+                        "status": "rejected",
+                        "reason": validation.reason,
+                        "comment_id": comment_id,
+                    }
 
                 await self._save(comment_id)
                 return {"status": "skipped", "comment_id": comment_id}


### PR DESCRIPTION
## Summary
- Add no-op `wake_up` signal to `CommentPollingWorkflow`
- Send the signal on worker startup so in-flight workflows get a workflow task and can re-evaluate `is_target_worker_deployment_version_changed()`
- Fixes the issue where long-running polling activities prevent version drain because no workflow task is delivered

## Test plan
- [ ] Deploy new version and verify polling workflow continues-as-new promptly
- [ ] Verify first deploy (no running workflow) logs gracefully and doesn't error