### PR TITLE
Fix replay determinism check silently pinning all workflows

### DIFF
--- a/.github/scripts/replay-determinism.sh
+++ b/.github/scripts/replay-determinism.sh
@@ -52,12 +52,12 @@ for history_file in "$DOWNLOAD_DIR"/*.json; do
 
   cp "$history_file" "$solo_dir/"
 
-  echo -n "Replaying $wid ... "
-  if REPLAY_HISTORIES_DIR="$solo_dir" uv run python -m pytest tests/test_replay_determinism.py -x -q --tb=short 2>/dev/null; then
-    echo "PASSED"
+  echo "Replaying $wid ..."
+  if REPLAY_HISTORIES_DIR="$solo_dir" uv run python -m pytest tests/test_replay_determinism.py -x -q --tb=short; then
+    echo "$wid ... PASSED"
     passed_workflows+=("$wid")
   else
-    echo "FAILED"
+    echo "$wid ... FAILED"
     failed_workflows+=("$wid")
   fi
 
@@ -77,29 +77,18 @@ for wid in "${passed_workflows[@]}"; do
 done
 
 for wid in "${failed_workflows[@]}"; do
-  echo "Setting $wid -> pinned"
-
-  versioning_info=$(temporal workflow describe \
-    --address "$TEMPORAL_ADDRESS" \
-    --namespace "$TEMPORAL_NAMESPACE" \
-    --workflow-id "$wid" \
-    --output json \
-    | jq -r '.workflowExecutionInfo.versioningInfo.deploymentVersion')
-
-  deploy_name=$(echo "$versioning_info" | jq -r '.deploymentName')
-  build_id=$(echo "$versioning_info" | jq -r '.buildId')
-
+  # Use unspecified so the application code can control its own upgrade path via CaN
+  echo "Setting $wid -> unspecified"
   temporal workflow update-options \
     --address "$TEMPORAL_ADDRESS" \
     --namespace "$TEMPORAL_NAMESPACE" \
     --workflow-id "$wid" \
     --versioning-override-behavior unspecified
-    # use unspecified so the application code can control its own upgrade path via CaN
 done
 
 echo ""
 if [ ${#failed_workflows[@]} -gt 0 ]; then
-  echo "WARNING: ${#failed_workflows[@]} workflow(s) failed replay and were pinned:"
+  echo "WARNING: ${#failed_workflows[@]} workflow(s) failed replay and were set to unspecified:"
   printf '  - %s\n' "${failed_workflows[@]}"
 else
   echo "All ${#passed_workflows[@]} workflow(s) passed replay — set to auto_upgrade"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,8 @@ venvPath = "."
 venv = ".venv"
 extraPaths = ["src"]
 typeCheckingMode = "standard"
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -85,6 +85,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "dotenv"
 version = "0.9.9"
 source = { registry = "https://pypi.org/simple" }
@@ -105,6 +114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "nexus-rpc"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -114,6 +132,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -158,6 +194,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -176,12 +237,20 @@ dependencies = [
     { name = "temporalio" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "praw", specifier = ">=7.8.1" },
     { name = "temporalio", specifier = ">=1.24.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
 
 [[package]]
 name = "requests"


### PR DESCRIPTION
## Summary
- Add `pytest` to a dev dependency group so `uv sync` installs it in CI. Without it, `uv run python -m pytest` fast-failed with `ModuleNotFoundError` and every workflow was treated as a replay failure.
- Drop `2>/dev/null` in `replay-determinism.sh` so tool errors vs. real non-determinism are visible.
- Rename the `-> pinned` log/WARNING text to `-> unspecified` to match the override that's actually applied, and remove the unused `versioning_info` lookup.

## Test plan
- [ ] Push/merge triggers the deploy workflow and the replay step completes in seconds per workflow, not milliseconds
- [ ] Replay log shows pytest output (PASSED or a real determinism diff), not a silent FAILED
- [ ] Running workflows are moved to `auto_upgrade` when replay passes